### PR TITLE
Fixing grafic centering when zooms are wrapped

### DIFF
--- a/genetIC/src/simulation/grid/grid.hpp
+++ b/genetIC/src/simulation/grid/grid.hpp
@@ -509,13 +509,17 @@ namespace grids {
 
     //! Wraps a point so that it lies within the periodic domain.
     Coordinate<T> wrapPoint(Coordinate<T> pos) const {
-      pos.x = fmod(pos.x, periodicDomainSize);
-      if (pos.x < 0) pos.x += periodicDomainSize;
-      pos.y = fmod(pos.y, periodicDomainSize);
-      if (pos.y < 0) pos.y += periodicDomainSize;
-      pos.z = fmod(pos.z, periodicDomainSize);
-      if (pos.z < 0) pos.z += periodicDomainSize;
+      pos.x = this->wrapIndividualCoordinate(pos.x);
+      pos.y = this->wrapIndividualCoordinate(pos.y);
+      pos.z = this->wrapIndividualCoordinate(pos.z);
       return pos;
+    }
+
+      //! Wraps a coordinate so that it lies within the periodic domain.
+    T wrapIndividualCoordinate(T x) const {
+      x = fmod(x, periodicDomainSize);
+      if (x < 0) x += periodicDomainSize;
+      return x;
     }
 
     /*! \brief True if cell with pixel coordinates is on this grid

--- a/genetIC/src/simulation/grid/virtualgrid.hpp
+++ b/genetIC/src/simulation/grid/virtualgrid.hpp
@@ -820,9 +820,9 @@ namespace grids {
     OffsetGrid(GridPtrType pUnderlying, T dx, T dy, T dz) :
       VirtualGrid<T>(pUnderlying, pUnderlying->periodicDomainSize, pUnderlying->size,
                      pUnderlying->cellSize,
-                     pUnderlying->offsetLower.x + dx,
-                     pUnderlying->offsetLower.y + dy,
-                     pUnderlying->offsetLower.z + dz,
+                     pUnderlying->wrapIndividualCoordinate(pUnderlying->offsetLower.x + dx),
+                     pUnderlying->wrapIndividualCoordinate(pUnderlying->offsetLower.y + dy),
+                     pUnderlying->wrapIndividualCoordinate(pUnderlying->offsetLower.z + dz),
                      pUnderlying->cellMassFrac,
                      pUnderlying->cellSofteningScale) {}
 

--- a/genetIC/tests/test_01h_zoom_grid_pos_offset/paramfile.txt
+++ b/genetIC/tests/test_01h_zoom_grid_pos_offset/paramfile.txt
@@ -1,4 +1,4 @@
-# Test velocity offset of output (including a zoom region)
+# Test position offset of output (including a zoom region)
 
 
 # output parameters

--- a/genetIC/tests/test_01i_zoom_pos_offset_wrap/paramfile.txt
+++ b/genetIC/tests/test_01i_zoom_pos_offset_wrap/paramfile.txt
@@ -1,0 +1,30 @@
+# Testing centering when the lower left corner of the zoom is wrapped (issue 69)
+
+# output parameters
+outdir	 ./
+outformat grafic
+outname test_1
+
+# cosmology:
+Om  0.279
+Ol  0.721
+s8  0.817
+zin	99
+camb	../camb_transfer_kmax40_z0.dat
+
+# basegrid 50 Mpc/h, 32^3
+basegrid 50.0 16
+
+# fourier seeding
+seed	8896131
+
+# Choose a center such that the zoom is nearly centered in x,
+# wrapped to the right in y and wrapped to the left in z
+centre 22.0000001 43.00001 2.000001
+select_sphere 5
+zoomgrid 4 16
+
+center_output
+done
+dump_grid 0
+dump_grid 1


### PR DESCRIPTION
Hi,

This PR fixes the GRAFIC-specific issue raised in #69, and implements an additional test to catch this behaviour.

Several things worth mentioning for documentation:
- The centering with Grafic is not as accurate as when using e.g. tipsy/gadget. This is because it works at the grid level, and therefore any offset is implemented in pixel units. The final target region is therefore centered plus or minus one coarse pixel (which can be physically large for very coarse grids used in the tests).

- I was worried that the new `OffsetGenerator` would apply the centering offset a second time, after the grid hierarchy has already been centered. However, this line ensures it does not:
https://github.com/ucl-cosmoparticles/genetIC/blob/a9eea2cce6ce0be6eebe67a37f073cb9df9fee57/genetIC/src/io/grafic.hpp#L177

 Comments welcome
Martin