### PR TITLE
Fix issue #85

### DIFF
--- a/genetIC/src/simulation/grid/grid.hpp
+++ b/genetIC/src/simulation/grid/grid.hpp
@@ -544,6 +544,13 @@ namespace grids {
       return i < size3;
     }
 
+    //! Returns the linear index of the point displaced from index by the co-ordinate vector step, wrapping around the *grid*
+    size_t getIndexFromIndexAndStepWithWrap(size_t index, const Coordinate<int> &step) const {
+      auto coord = getCoordinateFromIndex(index);
+      coord = this->wrapCoordinateAroundGrid(coord + step);
+      return this->getIndexFromCoordinate(coord);
+    }
+
     //! Returns the linear index of the point displaced from index by the co-ordinate vector step.
     size_t getIndexFromIndexAndStep(size_t index, const Coordinate<int> &step) const {
       auto coord = getCoordinateFromIndex(index);
@@ -563,6 +570,20 @@ namespace grids {
       if (coord.x < 0) coord.x += simEquivalentSize;
       if (coord.y < 0) coord.y += simEquivalentSize;
       if (coord.z < 0) coord.z += simEquivalentSize;
+      return coord;
+    }
+
+    /*! \brief Wrap the coordinate such that it lies within [0,size) (i.e. within the grid).
+     *
+     * Note that for efficiency this routine only "corrects" coordinates within one gridsize of the fundamental domain.
+     */
+    Coordinate<int> wrapCoordinateAroundGrid(Coordinate<int> coord) const {
+      if (coord.x > (signed) size - 1) coord.x -= size;
+      if (coord.y > (signed) size - 1) coord.y -= size;
+      if (coord.z > (signed) size - 1) coord.z -= size;
+      if (coord.x < 0) coord.x += size;
+      if (coord.y < 0) coord.y += size;
+      if (coord.z < 0) coord.z += size;
       return coord;
     }
 

--- a/genetIC/src/simulation/particles/zeldovich.hpp
+++ b/genetIC/src/simulation/particles/zeldovich.hpp
@@ -202,6 +202,10 @@ namespace particle {
 
       // Differentiation operator
       auto differentiate = [a, b, &potential](auto & zeldovichOffsetField, int dir) {
+        Coordinate<int> step_right, step_left;
+        step_right[dir] = 1;
+        step_left[dir] = -1;
+
         zeldovichOffsetField->toReal();
 
         // Create zeldovich offset field
@@ -213,29 +217,15 @@ namespace particle {
 
         // Iterate over cells and compute finite difference
         grid2.parallelIterateOverCellsSpatiallyClustered(
-           [&data, grid2, &potential, a, b, dir](size_t index){
+           [&data, &grid2, &potential, a, b, &step_left, &step_right](size_t index){
 
           size_t ind_p1, ind_m1, ind_p2, ind_m2;
-          auto coord = grid2.getCoordinateFromIndex(index);
-          auto coord_m1 = coord, coord_m2 = coord, coord_p1 = coord, coord_p2 = coord;
 
-          coord_m1[dir] -= 1;
-          coord_m2[dir] -= 2;
+          ind_m1 = grid2.getIndexFromIndexAndStepWithWrap(index, step_left);
+          ind_m2 = grid2.getIndexFromIndexAndStepWithWrap(ind_m1, step_left);
 
-          coord_p1[dir] += 1;
-          coord_p2[dir] += 2;
-
-          // Assume the grid is periodic (equivalent to what is done with Fourier)
-          if (coord_m1[dir] < 0) coord_m1[dir] += grid2.size;
-          if (coord_m2[dir] < 0) coord_m2[dir] += grid2.size;
-          if (coord_p1[dir] >= int(grid2.size)) coord_p1[dir] -= grid2.size;
-          if (coord_p2[dir] >= int(grid2.size)) coord_p2[dir] -= grid2.size;
-
-          ind_m1 = grid2.getIndexFromCoordinate(coord_m1);
-          ind_m2 = grid2.getIndexFromCoordinate(coord_m2);
-
-          ind_p1 = grid2.getIndexFromCoordinate(coord_p1);
-          ind_p2 = grid2.getIndexFromCoordinate(coord_p2);
+          ind_p1 = grid2.getIndexFromIndexAndStepWithWrap(index, step_right);
+          ind_p2 = grid2.getIndexFromIndexAndStepWithWrap(ind_p1, step_right);
 
           // 4th order stencil (with periodic boundaries)
           data[index] =


### PR DESCRIPTION
This relies on wrapping around *grid* boundaries (not domain boundary) when computing the indices of neighbouring cells to compute the Zeldovich offset. It prevents out-of-bound access.