### PR TITLE
Address inconsistency in big gadget files

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -53,6 +53,7 @@ jobs:
     - name: Install python dependencies
       shell: bash
       run: |
+        export CC=gcc-10
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install numpy scipy cython
         python -m pip install pynbody

--- a/genetIC/src/ic.hpp
+++ b/genetIC/src/ic.hpp
@@ -77,6 +77,9 @@ protected:
   //! Gadget type of flagged particles.
   unsigned int flaggedGadgetParticleType;
 
+  //! Number of gadget files (if in use)
+  int nGadgetFiles = 1;
+
   //! DM supersampling to perform on deepest zoom grid
   int supersample = 1;
 
@@ -654,6 +657,10 @@ public:
     exactPowerSpectrum = true;
   }
 
+  //! Set the number of gadget files to output (only does anything for gadget)
+  void setGadgetNumFiles(int nFiles) {
+    this->nGadgetFiles = nFiles;
+  }
 
   //! Set the gadget particle type to be produced by the deepest level currently in the grid hierarchy
   void setGadgetParticleType(unsigned int type) {
@@ -1245,7 +1252,8 @@ public:
       case OutputFormat::gadget3:
         gadget::save<float>(getOutputPath() + ".gadget", boxlen, *pMapper,
                             pParticleGenerator,
-                            cosmology, static_cast<int>(outputFormat));
+                            cosmology, static_cast<int>(outputFormat),
+                            nGadgetFiles);
         break;
       case OutputFormat::tipsy:
         tipsy::save(getOutputPath() + ".tipsy", boxlen, pParticleGenerator,

--- a/genetIC/src/io/gadget.hpp
+++ b/genetIC/src/io/gadget.hpp
@@ -114,7 +114,8 @@ namespace io {
 
 
     template<typename OutputFloatType, typename InternalFloatType>
-    io_header_2 createGadget2Header(vector<InternalFloatType> masses, vector<long> npart, double Boxlength,
+    io_header_2 createGadget2Header(vector<InternalFloatType> masses, vector<long> npart,
+                                    vector<long> npartTotal, int nFiles, double Boxlength,
                                     const cosmology::CosmologicalParameters<InternalFloatType> &cosmology) {
       io_header_2 header2;
       ::memset(&header2, 0, sizeof(io_header_2)); // ensure unused flags are all zero
@@ -134,21 +135,21 @@ namespace io {
       header2.redshift = cosmology.redshift;
       header2.flag_sfr = 0;
       header2.flag_feedback = 0;
-      header2.nPartTotal[0] = (unsigned int) (npart[0]);
-      header2.nPartTotal[1] = (unsigned int) (npart[1]);
-      header2.nPartTotal[2] = (unsigned int) (npart[2]);
-      header2.nPartTotal[3] = (unsigned int) (npart[3]);
-      header2.nPartTotal[4] = (unsigned int) (npart[4]);
-      header2.nPartTotal[5] = (unsigned int) (npart[5]);
+      header2.nPartTotal[0] = (unsigned int) (npartTotal[0]);
+      header2.nPartTotal[1] = (unsigned int) (npartTotal[1]);
+      header2.nPartTotal[2] = (unsigned int) (npartTotal[2]);
+      header2.nPartTotal[3] = (unsigned int) (npartTotal[3]);
+      header2.nPartTotal[4] = (unsigned int) (npartTotal[4]);
+      header2.nPartTotal[5] = (unsigned int) (npartTotal[5]);
       // Same basic thing should happen here as with gadget3:
-      header2.nPartTotalHighWord[0] = (unsigned int) (npart[0] >> 32);
-      header2.nPartTotalHighWord[1] = (unsigned int) (npart[1] >> 32);
-      header2.nPartTotalHighWord[2] = (unsigned int) (npart[2] >> 32);
-      header2.nPartTotalHighWord[3] = (unsigned int) (npart[3] >> 32);
-      header2.nPartTotalHighWord[4] = (unsigned int) (npart[4] >> 32);
-      header2.nPartTotalHighWord[5] = (unsigned int) (npart[5] >> 32);
+      header2.nPartTotalHighWord[0] = (unsigned int) (npartTotal[0] >> 32);
+      header2.nPartTotalHighWord[1] = (unsigned int) (npartTotal[1] >> 32);
+      header2.nPartTotalHighWord[2] = (unsigned int) (npartTotal[2] >> 32);
+      header2.nPartTotalHighWord[3] = (unsigned int) (npartTotal[3] >> 32);
+      header2.nPartTotalHighWord[4] = (unsigned int) (npartTotal[4] >> 32);
+      header2.nPartTotalHighWord[5] = (unsigned int) (npartTotal[5] >> 32);
       header2.flag_cooling = 0;
-      header2.num_files = 1;
+      header2.num_files = nFiles;
       header2.BoxSize = Boxlength;
       header2.Omega0 = cosmology.OmegaM0;
       header2.OmegaLambda = cosmology.OmegaLambda0;
@@ -159,7 +160,7 @@ namespace io {
       header2.flag_metals = 0;
       header2.flag_entropy_instead_u = 0;
 
-      if (npart[0] > 0) { //options for baryons
+      if (npartTotal[0] > 0) { //options for baryons
         header2.flag_sfr = 1;
         header2.flag_feedback = 1;
         header2.flag_cooling = 1;
@@ -170,7 +171,9 @@ namespace io {
     }
 
     template<typename OutputFloatType, typename InternalFloatType>
-    io_header_3 createGadget3Header(vector<InternalFloatType> masses, vector<long> npart, double Boxlength,
+    io_header_3 createGadget3Header(vector<InternalFloatType> masses, vector<long> npart,
+                                    vector<long> npartTotal, int nFiles,
+                                    double Boxlength,
                                     const cosmology::CosmologicalParameters<InternalFloatType> &cosmology) {
       io_header_3 header3;
       ::memset(&header3, 0, sizeof(io_header_3)); // ensure unused flags are all zero
@@ -190,32 +193,32 @@ namespace io {
       header3.redshift = cosmology.redshift;
       header3.flag_sfr = 0;
       header3.flag_feedback = 0;
-      header3.nPartTotal[0] = (unsigned int) (npart[0]);
-      header3.nPartTotal[1] = (unsigned int) (npart[1]);
-      header3.nPartTotal[2] = (unsigned int) (npart[2]);
-      header3.nPartTotal[3] = (unsigned int) (npart[3]);
-      header3.nPartTotal[4] = (unsigned int) (npart[4]);
-      header3.nPartTotal[5] = (unsigned int) (npart[5]);
+      header3.nPartTotal[0] = (unsigned int) (npartTotal[0]);
+      header3.nPartTotal[1] = (unsigned int) (npartTotal[1]);
+      header3.nPartTotal[2] = (unsigned int) (npartTotal[2]);
+      header3.nPartTotal[3] = (unsigned int) (npartTotal[3]);
+      header3.nPartTotal[4] = (unsigned int) (npartTotal[4]);
+      header3.nPartTotal[5] = (unsigned int) (npartTotal[5]);
       header3.flag_cooling = 0;
-      header3.num_files = 1;
+      header3.num_files = nFiles;
       header3.BoxSize = Boxlength;
       header3.Omega0 = cosmology.OmegaM0;
       header3.OmegaLambda = cosmology.OmegaLambda0;
       header3.HubbleParam = cosmology.hubble;
       header3.flag_stellarage = 0;  /*!< flags whether the file contains formation times of star particles */
       header3.flag_metals = 0;    /*!< flags whether the file contains metallicity values for gas and star  particles */
-      header3.nPartTotalHighWord[0] = (unsigned int) (npart[0] >> 32);
-      header3.nPartTotalHighWord[1] = (unsigned int) (npart[1] >> 32); //copied from Gadget3
-      header3.nPartTotalHighWord[2] = (unsigned int) (npart[2] >> 32);
-      header3.nPartTotalHighWord[3] = (unsigned int) (npart[3] >> 32);
-      header3.nPartTotalHighWord[4] = (unsigned int) (npart[4] >> 32);
-      header3.nPartTotalHighWord[5] = (unsigned int) (npart[5] >> 32);
+      header3.nPartTotalHighWord[0] = (unsigned int) (npartTotal[0] >> 32);
+      header3.nPartTotalHighWord[1] = (unsigned int) (npartTotal[1] >> 32); //copied from Gadget3
+      header3.nPartTotalHighWord[2] = (unsigned int) (npartTotal[2] >> 32);
+      header3.nPartTotalHighWord[3] = (unsigned int) (npartTotal[3] >> 32);
+      header3.nPartTotalHighWord[4] = (unsigned int) (npartTotal[4] >> 32);
+      header3.nPartTotalHighWord[5] = (unsigned int) (npartTotal[5] >> 32);
       header3.flag_entropy_instead_u = 0; /*!< flags that IC-file contains entropy instead of u */
       header3.flag_doubleprecision = tools::datatypes::floatinfo<OutputFloatType>::doubleprecision;
       header3.flag_ic_info = 1;
       header3.lpt_scalingfactor = 0.f; /*!dummy value since we never use ic_info!=1 */
 
-      if (npart[0] > 0) { //options for baryons & special behavior
+      if (npartTotal[0] > 0) { //options for baryons & special behavior
         header3.flag_sfr = 1;
         header3.flag_feedback = 1;
         header3.flag_cooling = 1;
@@ -240,14 +243,15 @@ namespace io {
       particle::mapper::ParticleMapper<GridDataType> &mapper; //!< Particle mapper, for relating offsets in the file to GenetIC grid cells.
       particle::SpeciesToGeneratorMap<GridDataType> generators; //!< Particle generators for each particle species.
       const cosmology::CosmologicalParameters<InternalFloatType> &cosmology; //!< Struct containing cosmological parameters.
-      tools::MemMapFileWriter writer; //!< Low-level file operations are handled by this object.
+      std::vector<tools::MemMapFileWriter> writers; //!< Low-level file operations are handled by this object.
       size_t nTotal; //!< Total number of particles to output.
+      std::vector<size_t> nTotalPerFile; //!< Number of particles to write per file
       double boxLength; //!< Size of simulation box.
       int gadgetVersion; //!< Which version of the gadget file to output. Allowed values 2 or 3.
       vector<InternalFloatType> masses; //!< Masses of particles if constant. Zero if variable.
-      vector<long> npart; //!< Number of particles of each gadget type
+      vector<long> nPartPerType; //!< Number of particles of each gadget type
       bool variableMass; //!< Stores whether we are using variable mass gadget particles
-
+      int nFiles = 1; //!< Number of files to write
 
       // Mapping between gadget particle types (0->6) and our internal field type. This selects the appropriate
       // transfer function, if multiple are being used.
@@ -266,7 +270,10 @@ namespace io {
 
         size_t current_n = 0;
 
-        auto currentWriteBlockC = writer.getMemMapFortran<WriteType>(nTotal);
+        std::vector<decltype(writers[0].getMemMapFortran<WriteType>(std::declval<size_t>()))> currentWriteBlocks;
+
+        for(int i=0; i<nFiles; i++)
+          currentWriteBlocks.push_back(writers[i].getMemMapFortran<WriteType>(nTotalPerFile[i]));
 
         for (unsigned int particle_type = 0; particle_type < 6; particle_type++) {
           auto begin = mapper.beginParticleType(*generators[gadgetTypeToSpecies[particle_type]], particle_type);
@@ -275,8 +282,17 @@ namespace io {
 
           current_n += begin.parallelIterate(
             [&](size_t n_offset, const particle::mapper::MapperIterator<GridDataType> &localIterator) {
+              int fileNum = 0;
               size_t addr = n_offset + current_n;
-              currentWriteBlockC[addr] = getData(localIterator);
+
+              // now figure out which file to dump this into.
+              // TODO: It's possible this is a bit slow?
+              while(addr>=nTotalPerFile[fileNum]) {
+                addr-=nTotalPerFile[fileNum];
+                fileNum++;
+              }
+
+              currentWriteBlocks[fileNum][addr] = getData(localIterator);
             }, nMax);
 
         }
@@ -289,7 +305,7 @@ namespace io {
       void preScanForMassesAndParticleNumbers() {
         variableMass = false;
         masses = vector<InternalFloatType>(6, 0.0);
-        npart = vector<long>(6, 0);
+        nPartPerType = vector<long>(6, 0);
         nTotal = 0;
 
         logging::entry() << "Particles by gadget type:" << endl;
@@ -304,7 +320,7 @@ namespace io {
             }
 
             logging::entry() << "   Particle type " << ptype << ": " << n << " particles" << endl;
-            npart[ptype] = n;
+            nPartPerType[ptype] = n;
             masses[ptype] = min_mass;
             nTotal += n;
           }
@@ -318,6 +334,21 @@ namespace io {
         } else {
           logging::entry() << "Using fixed-mass gadget format" << endl;
         }
+
+        for(int i=0; i<nFiles; i++) {
+          if (i == nFiles - 1) // last file
+            nTotalPerFile.push_back(nTotal - (nTotal / nFiles) * (nFiles - 1));
+          else
+            nTotalPerFile.push_back(nTotal / nFiles);
+        }
+
+        if(nFiles>1) {
+          logging::entry() << "Particles per file: ";
+          for (int i = 0; i < nFiles; i++)
+            std::cerr << nTotalPerFile[i] << " ";
+          std::cerr << endl;
+        }
+
       }
 
       //! \brief Extract the minimum mass, maximum mass, and number of a particle species
@@ -341,12 +372,49 @@ namespace io {
 
       //! \brief Output the gadget3 or gadget2 header:
       void writeHeader() {
-        if (gadgetVersion == 3) {
-          writer.writeFortran(createGadget3Header<OutputFloatType>(masses, npart, boxLength, cosmology));
-        } else if (gadgetVersion == 2) {
-          writer.writeFortran(createGadget2Header<OutputFloatType>(masses, npart, boxLength, cosmology));
-        } else {
-          throw std::runtime_error("Unknown gadget format");
+        std::vector<long> nPartPerTypeThisFile(6, 0);
+        std::vector<long> nPartRemainingPerType = nPartPerType;
+        size_t offset = 0;
+
+        for(int i=0; i<nFiles; i++) {
+
+          size_t nPartRemainingInFile = nTotalPerFile[i];
+
+          // now figure out what gadget particle types are going to appear in this particular file
+          for(int partType = 0; partType<6 ; partType++) {
+            if(nPartRemainingPerType[partType] < nPartRemainingInFile)
+              nPartPerTypeThisFile[partType] = nPartRemainingPerType[partType];
+            else
+              nPartPerTypeThisFile[partType] = nPartRemainingInFile;
+
+            nPartRemainingInFile-=nPartPerTypeThisFile[partType];
+            nPartRemainingPerType[partType]-=nPartPerTypeThisFile[partType];
+          }
+
+          logging::entry(logging::debug) << "i=" << i << " nPartPerTypeThisFile = ";
+          for(int partType=0; partType<6; partType++) {
+            std::cerr << nPartPerTypeThisFile[partType] << " ";
+          }
+          std::cerr << std::endl;
+
+          logging::entry(logging::debug) << " nPartPerType = ";
+          for(int partType=0; partType<6; partType++) {
+            std::cerr << nPartPerType[partType] << " ";
+          }
+
+          std::cerr << std::endl;
+
+          assert(nPartRemainingInFile == 0); // ensure we have assigned all the particles to a type
+
+          if (gadgetVersion == 3) {
+            writers[i].writeFortran(createGadget3Header<OutputFloatType>(masses, nPartPerTypeThisFile, nPartPerType, nFiles,
+                                                                         boxLength, cosmology));
+          } else if (gadgetVersion == 2) {
+            writers[i].writeFortran(createGadget2Header<OutputFloatType>(masses, nPartPerTypeThisFile, nPartPerType, nFiles,
+                                                                         boxLength, cosmology));
+          } else {
+            throw std::runtime_error("Unknown gadget format");
+          }
         }
       }
 
@@ -363,9 +431,9 @@ namespace io {
                    particle::mapper::ParticleMapper<GridDataType> &mapper,
                    const particle::SpeciesToGeneratorMap<GridDataType> &generators_,
                    const cosmology::CosmologicalParameters<tools::datatypes::strip_complex<GridDataType>> &cosmology,
-                   int gadgetVersion) :
+                   int gadgetVersion, int numFiles) :
         mapper(mapper), generators(generators_), cosmology(cosmology), boxLength(boxLength),
-        gadgetVersion(gadgetVersion) {
+        gadgetVersion(gadgetVersion), nFiles(numFiles) {
       }
 
       //! \brief Operation to save gadget particles
@@ -373,7 +441,13 @@ namespace io {
 
         preScanForMassesAndParticleNumbers();
 
-        writer = tools::MemMapFileWriter(name + std::to_string(gadgetVersion));
+        if(nFiles==1) {
+          writers.push_back(tools::MemMapFileWriter(name + std::to_string(gadgetVersion)));
+        } else {
+          for(int i=0; i<nFiles; i++) {
+            writers.push_back(tools::MemMapFileWriter(name + std::to_string(gadgetVersion) + "." + std::to_string(i)));
+          }
+        }
 
         writeHeader();
 
@@ -425,9 +499,9 @@ namespace io {
               particle::mapper::ParticleMapper<GridDataType> &mapper,
               particle::SpeciesToGeneratorMap<GridDataType> &generators,
               const cosmology::CosmologicalParameters<tools::datatypes::strip_complex<GridDataType>> &cosmology,
-              int gadgetformat) {
+              int gadgetformat, int nFiles) {
 
-      GadgetOutput<GridDataType, OutputFloatType> output(Boxlength, mapper, generators, cosmology, gadgetformat);
+      GadgetOutput<GridDataType, OutputFloatType> output(Boxlength, mapper, generators, cosmology, gadgetformat, nFiles);
       output(name);
 
     }

--- a/genetIC/src/io/gadget.hpp
+++ b/genetIC/src/io/gadget.hpp
@@ -320,6 +320,7 @@ namespace io {
             }
 
             logging::entry() << "   Particle type " << ptype << ": " << n << " particles" << endl;
+
             nPartPerType[ptype] = n;
             masses[ptype] = min_mass;
             nTotal += n;
@@ -342,12 +343,14 @@ namespace io {
             nTotalPerFile.push_back(nTotal / nFiles);
         }
 
+#ifdef DEBUG_INFO
         if(nFiles>1) {
           logging::entry() << "Particles per file: ";
           for (int i = 0; i < nFiles; i++)
             std::cerr << nTotalPerFile[i] << " ";
           std::cerr << endl;
         }
+#endif
 
       }
 
@@ -391,18 +394,14 @@ namespace io {
             nPartRemainingPerType[partType]-=nPartPerTypeThisFile[partType];
           }
 
+#ifdef DEBUG_INFO
           logging::entry(logging::debug) << "i=" << i << " nPartPerTypeThisFile = ";
           for(int partType=0; partType<6; partType++) {
             std::cerr << nPartPerTypeThisFile[partType] << " ";
           }
           std::cerr << std::endl;
+#endif
 
-          logging::entry(logging::debug) << " nPartPerType = ";
-          for(int partType=0; partType<6; partType++) {
-            std::cerr << nPartPerType[partType] << " ";
-          }
-
-          std::cerr << std::endl;
 
           assert(nPartRemainingInFile == 0); // ensure we have assigned all the particles to a type
 

--- a/genetIC/src/io/gadget.hpp
+++ b/genetIC/src/io/gadget.hpp
@@ -285,8 +285,10 @@ namespace io {
               int fileNum = 0;
               size_t addr = n_offset + current_n;
 
-              // now figure out which file to dump this into.
-              // TODO: It's possible this is a bit slow?
+              // Now figure out which file to dump this into.
+              // The following approach looks slow (doing it for every particle!),
+              // but code profiling suggests it's not a significant overhead.
+              // Easier to do this than to try and have thread-local variables
               while(addr>=nTotalPerFile[fileNum]) {
                 addr-=nTotalPerFile[fileNum];
                 fileNum++;

--- a/genetIC/src/main.cpp
+++ b/genetIC/src/main.cpp
@@ -75,6 +75,7 @@ void setup_parser(tools::ClassDispatch<ICf, void> &dispatch) {
   // Gadget options
   dispatch.add_class_route("gadget_particle_type", &ICf::setGadgetParticleType);
   dispatch.add_class_route("gadget_flagged_particle_type", &ICf::setFlaggedGadgetParticleType);
+  dispatch.add_class_route("gadget_num_files", &ICf::setGadgetNumFiles);
 
   // Define input files
   dispatch.add_class_route("mapper_relative_to", &ICf::setInputMapper);

--- a/genetIC/src/tools/memmap.hpp
+++ b/genetIC/src/tools/memmap.hpp
@@ -173,7 +173,14 @@ namespace tools {
     //! Get a memory-mapped view of the file for writing, and surround it with Fortran-style size blocks
     template<typename DataType>
     auto getMemMapFortran(size_t n_elements) {
-      int fortranFieldSize = n_elements*sizeof(DataType);
+      size_t fieldSize = n_elements*sizeof(DataType);
+      int fortranFieldSize;
+
+      if(fieldSize>std::numeric_limits<int>::max())
+        fortranFieldSize=std::numeric_limits<int>::max(); // unclear what else to do
+      else
+        fortranFieldSize = int(fieldSize);
+
       write(fortranFieldSize);
       auto region = getMemMap<DataType>(n_elements);
       write(fortranFieldSize);

--- a/genetIC/src/tools/memmap.hpp
+++ b/genetIC/src/tools/memmap.hpp
@@ -176,9 +176,12 @@ namespace tools {
       size_t fieldSize = n_elements*sizeof(DataType);
       int fortranFieldSize;
 
-      if(fieldSize>std::numeric_limits<int>::max())
-        fortranFieldSize=std::numeric_limits<int>::max(); // unclear what else to do
-      else
+      if(fieldSize>std::numeric_limits<int>::max()) {
+        fortranFieldSize = std::numeric_limits<int>::max(); // unclear what else to do
+        logging::entry(logging::warning) << "One of the output Fortran fields is too large for the file format." << std::endl;
+        logging::entry(logging::warning) << "Writing will proceed, but the resulting file may appear corrupt" << std::endl;
+        logging::entry(logging::warning) << "Try using gadget_num_files <n> to split your output into multiple files." << std::endl;
+      } else
         fortranFieldSize = int(fieldSize);
 
       write(fortranFieldSize);

--- a/genetIC/tests/test_10f_gadget_multifile/paramfile.txt
+++ b/genetIC/tests/test_10f_gadget_multifile/paramfile.txt
@@ -1,0 +1,36 @@
+# Based on test 10c, but use multi-file gadget output
+
+
+# output parameters
+outdir	 ./
+outformat gadget3
+outname test_1
+gadget_num_files 7
+
+# cosmology:
+Om  0.279
+Ol  0.721
+s8  0.817
+zin	99
+camb	../camb_transfer_kmax40_z0.dat
+
+# basegrid 50 Mpc/h, 64^3
+basegrid 50.0 64
+gadget_particle_type 1
+
+
+# fourier seeding
+random_seed_real_space	8896131
+
+
+
+idfile zoomtest.txt
+
+zoomgrid 3 64
+gadget_particle_type 0
+
+
+
+
+
+done

--- a/genetIC/tests/test_10f_gadget_multifile/reference_output
+++ b/genetIC/tests/test_10f_gadget_multifile/reference_output
@@ -1,0 +1,1 @@
+../test_10c_gadget_zoom_ptype/reference_output

--- a/genetIC/tests/test_10f_gadget_multifile/zoomtest.txt
+++ b/genetIC/tests/test_10f_gadget_multifile/zoomtest.txt
@@ -1,0 +1,1 @@
+../test_10c_gadget_zoom_ptype/zoomtest.txt

--- a/tools/compare.py
+++ b/tools/compare.py
@@ -188,7 +188,12 @@ def check_comparison_is_possible(dirname):
 
 
 def particle_files_in_dir(dirname):
-    return glob.glob(dirname + "/*.tipsy") + glob.glob(dirname + "/*.gadget?")
+    gadget_multifiles = glob.glob(dirname + "/*.gadget?.0")
+    if len(gadget_multifiles) == 1:
+        gadget_multifiles = [gadget_multifiles[0][:-2]]
+    elif len(gadget_multifiles) > 1:
+        raise IOError("There is more than one particle output file to test against.")
+    return glob.glob(dirname + "/*.tipsy") + glob.glob(dirname + "/*.gadget?") + gadget_multifiles
 
 
 def default_comparisons():


### PR DESCRIPTION
Gadget uses a fortran-style file format, with integers saying how long different data blocks are.

By casting a size_t to an int, when this overflowed the behaviour was undefined.

In practice, zeros got written into the fortran length field which did not play nice with pynbody.

Fix by setting fortran field size to numeric_limits<int>::max() in these circumstances, and issuing a warning.

Add an option to split gadget output across multiple files.