### PR TITLE
Improve lustre file performance

### DIFF
--- a/genetIC/src/tools/memmap.hpp
+++ b/genetIC/src/tools/memmap.hpp
@@ -59,7 +59,7 @@ namespace tools {
      //! Destructor - exit with an error if we detect something has gone wrong deleting the memory map
     ~MemMapRegion() {
       if (addr_aligned != nullptr) {
-        msync(addr_aligned, size_bytes, MS_SYNC);
+        msync(addr_aligned, size_bytes, MS_ASYNC);
         if(munmap(addr_aligned, size_bytes)!=0) {
           // This probably indicates something has gone catastrophically wrong...
           logging::entry() << "ERROR: Failed to delete the mem-map (reason: " << ::strerror(errno) << ")" << std::endl;
@@ -86,6 +86,7 @@ namespace tools {
       this->addr = move.addr;
       this->addr_aligned = move.addr_aligned;
       this->size_bytes = move.size_bytes;
+      move.addr = nullptr;
       move.addr_aligned = nullptr;
       return (*this);
     }


### PR DESCRIPTION
Improve lustre file writing performance by changing synchronous to asynchronous write when finishing with memmap

Also improve clarity of move operation by setting addr to nullptr (as well as addr_aligned)