### PR TITLE
Address memory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(SOURCE_FILES
         genetIC/src/simulation/modifications/quadraticmodification.hpp
         genetIC/src/simulation/multilevelgrid/mask.hpp
         genetIC/src/tools/memmap.hpp
-        genetIC/src/tools/numerics/tricubic.hpp genetIC/src/tools/logging.hpp genetIC/src/tools/logging.cpp genetIC/src/simulation/modifications/splice.hpp)
+        genetIC/src/tools/numerics/tricubic.hpp genetIC/src/tools/logging.hpp genetIC/src/tools/logging.cpp genetIC/src/simulation/modifications/splice.hpp genetIC/src/tools/lru_cache.hpp)
 
 include_directories( /opt/local/include )
 link_directories(/opt/local/lib )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ set(SOURCE_FILES
 include_directories( /opt/local/include )
 link_directories(/opt/local/lib )
 include_directories( genetIC/  )
-link_libraries(fftw3 m fftw3 fftw3_threads gsl gslcblas)
+link_libraries(fftw3 m fftw3f fftw3_threads gsl gslcblas)
 
 
 exec_program(
@@ -113,6 +113,7 @@ add_definitions(-DCUBIC_INTERPOLATION
         -DGIT_MODIFIED="${GIT_MODIFIED}"
         -DDOUBLEPRECISION
         -DOUTPUT_IN_DOUBLEPRECISION
-        -DZELDOVICH_GRADIENT_FOURIER_SPACE)
+        -DZELDOVICH_GRADIENT_FOURIER_SPACE
+        )
 add_compile_options(-Wextra)
 add_executable(genetIC ${SOURCE_FILES})

--- a/genetIC/Makefile
+++ b/genetIC/Makefile
@@ -36,7 +36,7 @@ GSLFLAGS = -lgsl -lgslcblas
 # Note that genetIC no longer supports the use of FFTW2
 
 FFTW = -DFFTW3 -DFFTW_THREADS
-FFTWLIB = -lfftw3 -lfftw3_threads
+FFTWLIB = -lfftw3 -lfftw3f -lfftw3_threads
 
 
 # Provide information on the git repository, to be printed out on each run

--- a/genetIC/src/cosmology/camb.hpp
+++ b/genetIC/src/cosmology/camb.hpp
@@ -28,8 +28,9 @@ namespace cosmology {
   template<typename F>
   struct CacheKeyComparator {
     bool operator()(const F &a, const F &b) const {
-      bool ptr_less = std::owner_less<typename F::first_type>()(a.first, b.first);
-      return ptr_less || (!ptr_less && a.second < b.second); // equivalent to normal std::pair sorting
+      return std::owner_less<typename F::first_type>()(a.first, b.first) ||
+             (!std::owner_less<typename F::first_type>()(b.first, a.first) && a.second < b.second);
+
     }
   };
 
@@ -54,8 +55,6 @@ namespace cosmology {
       CacheKeyComparator<CacheKeyType>> calculatedCovariancesCache;
 
   public:
-
-    virtual ~PowerSpectrum() {}
 
     //! \brief Evaluate power spectrum for a given species at wavenumber k (Mpc/h), including the normalisation
     //! transferType specifies the transfer function to use (currently dm or baryon)

--- a/genetIC/src/cosmology/camb.hpp
+++ b/genetIC/src/cosmology/camb.hpp
@@ -161,8 +161,8 @@ namespace cosmology {
     using typename PowerSpectrum<DataType>::CoordinateType;
 
   protected:
-    std::vector<CoordinateType> kInterpolationPoints; //!< Wavenumbers read from CAMB file
-    std::map<particle::species, std::vector<CoordinateType>> speciesToInterpolationPoints; //!< Vector to store transfer functions
+    std::vector<double> kInterpolationPoints; //!< Wavenumbers read from CAMB file
+    std::map<particle::species, std::vector<double>> speciesToInterpolationPoints; //!< Vector to store transfer functions
 
     const std::map<particle::species, size_t> speciesToCambColumn
       {{particle::species::dm, 1},
@@ -171,7 +171,7 @@ namespace cosmology {
      }};
       //!< Columns of CAMB that we request for DM and baryons respectively
 
-    std::map<particle::species, tools::numerics::LogInterpolator<CoordinateType>> speciesToTransferFunction; //!< Interpolation functions:
+    std::map<particle::species, tools::numerics::LogInterpolator<double>> speciesToTransferFunction; //!< Interpolation functions:
     CoordinateType amplitude; //!< Amplitude of the initial power spectrum
     CoordinateType ns;        //!< tensor to scalar ratio of the initial power spectrum
     mutable CoordinateType kcamb_max_in_file; //!< Maximum CAMB wavenumber. If too small compared to grid resolution, Meszaros solution will be computed

--- a/genetIC/src/ic.hpp
+++ b/genetIC/src/ic.hpp
@@ -49,11 +49,11 @@ class DummyICGenerator;
 */
 template<typename GridDataType>
 class ICGenerator {
+public:
+  using T = tools::datatypes::strip_complex<GridDataType>;
 protected:
 
-  using T = tools::datatypes::strip_complex<GridDataType>;
   using GridPtrType = std::shared_ptr<grids::Grid<T>>;
-
 
   friend class DummyICGenerator<GridDataType>;
 

--- a/genetIC/src/main.cpp
+++ b/genetIC/src/main.cpp
@@ -9,164 +9,163 @@
 #include "ic.hpp"
 #include "dummyic.hpp"
 
+int runGenetic(string paramFilename);
 
-#ifdef DOUBLEPRECISION
-typedef double FloatType;
-#else
-typedef float FloatType;
-#endif
-
-// #define USE_COMPLEX_FFT
 #ifdef USE_COMPLEX_FFT
-using ICf = ICGenerator<complex<FloatType>> ;
+using ICf = ICGenerator<complex<float>>;
+using ICd = ICGenerator<complex<double>>;
 #else
-using ICf = ICGenerator<FloatType>;
+using ICf = ICGenerator<float>;
+using ICd = ICGenerator<double>;
 #endif
 
-void setup_parser(tools::ClassDispatch<ICf, void> &dispatch) {
+template<typename ICType>
+void setup_parser(tools::ClassDispatch<ICType, void> &dispatch) {
+
+  using FloatType = typename ICType::T;
 
   // Link command names used in parameter file to methods
 
   // Set the cosmology
-  dispatch.add_class_route("TCMB", &ICf::setTCMB);
-  dispatch.add_class_route("Om", &ICf::setOmegaM0);
-  dispatch.add_class_route("Ob", &ICf::setOmegaB0);
-  dispatch.add_class_route("Ol", &ICf::setOmegaLambda0);
-  dispatch.add_class_route("hubble", &ICf::setHubble);
-  dispatch.add_class_route("s8", &ICf::setSigma8);
-  dispatch.add_class_route("ns", &ICf::setns);
-  dispatch.add_class_route("zin", &ICf::setZ0);
-  dispatch.add_class_route("z", &ICf::setZ0);
+  dispatch.add_class_route("TCMB", &ICType::setTCMB);
+  dispatch.add_class_route("Om", &ICType::setOmegaM0);
+  dispatch.add_class_route("Ob", &ICType::setOmegaB0);
+  dispatch.add_class_route("Ol", &ICType::setOmegaLambda0);
+  dispatch.add_class_route("hubble", &ICType::setHubble);
+  dispatch.add_class_route("s8", &ICType::setSigma8);
+  dispatch.add_class_route("ns", &ICType::setns);
+  dispatch.add_class_route("zin", &ICType::setZ0);
+  dispatch.add_class_route("z", &ICType::setZ0);
 
   // Set seeds for random draws
   // Static casts here needed to differentiate between overloaded versions of setSeed,
   // now that we have both DM and baryon fields to seed.
   // DEPRECATED forms:
-  dispatch.add_deprecated_class_route("seed", "random_seed_real_space", static_cast<void (ICf::*)(int)>(&ICf::setSeed));
-  dispatch.add_deprecated_class_route("seedfourier", "random_seed_serial", static_cast<void (ICf::*)(int)>(&ICf::setSeedFourier));
-  dispatch.add_class_route("seedfourier_reverse", static_cast<void (ICf::*)(int)>(&ICf::setSeedFourierReverseOrder));
-  dispatch.add_deprecated_class_route("seedfourier_parallel", "random_seed", static_cast<void (ICf::*)(int)>(&ICf::setSeedFourierParallel));
+  dispatch.add_deprecated_class_route("seed", "random_seed_real_space", static_cast<void (ICType::*)(int)>(&ICType::setSeed));
+  dispatch.add_deprecated_class_route("seedfourier", "random_seed_serial", static_cast<void (ICType::*)(int)>(&ICType::setSeedFourier));
+  dispatch.add_class_route("seedfourier_reverse", static_cast<void (ICType::*)(int)>(&ICType::setSeedFourierReverseOrder));
+  dispatch.add_deprecated_class_route("seedfourier_parallel", "random_seed", static_cast<void (ICType::*)(int)>(&ICType::setSeedFourierParallel));
 
   // NEW FORMS, May 2020, ahead of release (to steer people towards a sensible default)
-  dispatch.add_class_route("random_seed", static_cast<void (ICf::*)(int)>(&ICf::setSeedFourierParallel));
-  dispatch.add_class_route("random_seed_serial", static_cast<void (ICf::*)(int)>(&ICf::setSeedFourier));
-  dispatch.add_class_route("random_seed_real_space", static_cast<void (ICf::*)(int)>(&ICf::setSeed));
+  dispatch.add_class_route("random_seed", static_cast<void (ICType::*)(int)>(&ICType::setSeedFourierParallel));
+  dispatch.add_class_route("random_seed_serial", static_cast<void (ICType::*)(int)>(&ICType::setSeedFourier));
+  dispatch.add_class_route("random_seed_real_space", static_cast<void (ICType::*)(int)>(&ICType::setSeed));
 
   // Optional computational properties
-  dispatch.add_deprecated_class_route("exact_power_spectrum_enforcement", "fix_power", &ICf::setExactPowerSpectrumEnforcement);
-  dispatch.add_class_route("fix_power", &ICf::setExactPowerSpectrumEnforcement);
+  dispatch.add_deprecated_class_route("exact_power_spectrum_enforcement", "fix_power", &ICType::setExactPowerSpectrumEnforcement);
+  dispatch.add_class_route("fix_power", &ICType::setExactPowerSpectrumEnforcement);
 
-  dispatch.add_class_route("strays_on", &ICf::setStraysOn);
-  dispatch.add_class_route("supersample", &ICf::setSupersample);
-  dispatch.add_class_route("supersample_gas", &ICf::setSupersampleGas);
-  dispatch.add_class_route("subsample", &ICf::setSubsample);
-  dispatch.add_class_route("eps_norm", &ICf::setEpsNorm);
+  dispatch.add_class_route("strays_on", &ICType::setStraysOn);
+  dispatch.add_class_route("supersample", &ICType::setSupersample);
+  dispatch.add_class_route("supersample_gas", &ICType::setSupersampleGas);
+  dispatch.add_class_route("subsample", &ICType::setSubsample);
+  dispatch.add_class_route("eps_norm", &ICType::setEpsNorm);
 
   // Grafic options
-  dispatch.add_class_route("pvar", &ICf::setpvarValue);
+  dispatch.add_class_route("pvar", &ICType::setpvarValue);
   dispatch.add_deprecated_class_route("center_grafic_output", "center_output",
-                           &ICf::setCenteringOnRegion);
+                           &ICType::setCenteringOnRegion);
 
 
-  dispatch.add_class_route("centre_output", &ICf::setCenteringOnRegion);
+  dispatch.add_class_route("centre_output", &ICType::setCenteringOnRegion);
   // US variant:
-  dispatch.add_class_route("center_output", &ICf::setCenteringOnRegion);
+  dispatch.add_class_route("center_output", &ICType::setCenteringOnRegion);
 
   // Gadget options
-  dispatch.add_class_route("gadget_particle_type", &ICf::setGadgetParticleType);
-  dispatch.add_class_route("gadget_flagged_particle_type", &ICf::setFlaggedGadgetParticleType);
-  dispatch.add_class_route("gadget_num_files", &ICf::setGadgetNumFiles);
+  dispatch.add_class_route("gadget_particle_type", &ICType::setGadgetParticleType);
+  dispatch.add_class_route("gadget_flagged_particle_type", &ICType::setFlaggedGadgetParticleType);
+  dispatch.add_class_route("gadget_num_files", &ICType::setGadgetNumFiles);
 
   // Define input files
-  dispatch.add_class_route("mapper_relative_to", &ICf::setInputMapper);
-  dispatch.add_class_route("camb", &ICf::setCambDat);
-  dispatch.add_class_route("powerlaw_amplitude", &ICf::setPowerLawAmplitude);
+  dispatch.add_class_route("mapper_relative_to", &ICType::setInputMapper);
+  dispatch.add_class_route("camb", &ICType::setCambDat);
+  dispatch.add_class_route("powerlaw_amplitude", &ICType::setPowerLawAmplitude);
 
   // Set output paths and format
-  dispatch.add_class_route("outdir", &ICf::setOutDir);
-  dispatch.add_class_route("outname", &ICf::setOutName);
-  dispatch.add_class_route("outformat", &ICf::setOutputFormat);
+  dispatch.add_class_route("outdir", &ICType::setOutDir);
+  dispatch.add_class_route("outname", &ICType::setOutName);
+  dispatch.add_class_route("outformat", &ICType::setOutputFormat);
 
   // Define grid structure - OLD NAMES
-  dispatch.add_deprecated_class_route("basegrid", "base_grid", &ICf::initBaseGrid);
-  dispatch.add_deprecated_class_route("zoomgrid", "zoom_grid", &ICf::initZoomGrid);
-  dispatch.add_deprecated_class_route("zoomgrid_with_origin_at", "zoom_grid_with_origin_at", &ICf::initZoomGridWithLowLeftCornerAt);
+  dispatch.add_deprecated_class_route("basegrid", "base_grid", &ICType::initBaseGrid);
+  dispatch.add_deprecated_class_route("zoomgrid", "zoom_grid", &ICType::initZoomGrid);
+  dispatch.add_deprecated_class_route("zoomgrid_with_origin_at", "zoom_grid_with_origin_at", &ICType::initZoomGridWithLowLeftCornerAt);
 
   // Define grid structure - NEW NAMES May 2020
-  dispatch.add_class_route("base_grid", &ICf::initBaseGrid);
-  dispatch.add_class_route("zoom_grid", &ICf::initZoomGrid);
-  dispatch.add_class_route("zoom_grid_with_origin_at", &ICf::initZoomGridWithLowLeftCornerAt);
+  dispatch.add_class_route("base_grid", &ICType::initBaseGrid);
+  dispatch.add_class_route("zoom_grid", &ICType::initZoomGrid);
+  dispatch.add_class_route("zoom_grid_with_origin_at", &ICType::initZoomGridWithLowLeftCornerAt);
 
 
   // Input Output of flagged particles - OLD NAMES
-  dispatch.add_deprecated_class_route("IDfile", "id_file", &ICf::loadID);
-  dispatch.add_deprecated_class_route("append_IDfile", "merge_id_file", &ICf::appendID);
-  dispatch.add_deprecated_class_route("dump_IDfile","dump_id_file", &ICf::dumpID);
+  dispatch.add_deprecated_class_route("IDfile", "id_file", &ICType::loadID);
+  dispatch.add_deprecated_class_route("append_IDfile", "merge_id_file", &ICType::appendID);
+  dispatch.add_deprecated_class_route("dump_IDfile","dump_id_file", &ICType::dumpID);
 
   // I/O of flagged particles - NEW NAMES May 2020
-  dispatch.add_class_route("id_file", &ICf::loadID);
-  dispatch.add_class_route("merge_id_file", &ICf::appendID);
-  dispatch.add_class_route("dump_id_file", &ICf::dumpID);
+  dispatch.add_class_route("id_file", &ICType::loadID);
+  dispatch.add_class_route("merge_id_file", &ICType::appendID);
+  dispatch.add_class_route("dump_id_file", &ICType::dumpID);
 
   // Point to specific coordinates:
-  dispatch.add_class_route("centre_on", &ICf::centreParticle);
-  dispatch.add_class_route("centre", &ICf::setCentre);
+  dispatch.add_class_route("centre_on", &ICType::centreParticle);
+  dispatch.add_class_route("centre", &ICType::setCentre);
 
   // US variants:
-  dispatch.add_class_route("center_on", &ICf::centreParticle);
-  dispatch.add_class_route("center", &ICf::setCentre);
+  dispatch.add_class_route("center_on", &ICType::centreParticle);
+  dispatch.add_class_route("center", &ICType::setCentre);
 
   // Flag cells
-  dispatch.add_class_route("select_sphere", &ICf::selectSphere);
-  dispatch.add_class_route("select_ellipse", &ICf::selectEllipse);
-  dispatch.add_class_route("select_cube", &ICf::selectCube);
-  dispatch.add_class_route("select_nearest", &ICf::selectNearest);
-  dispatch.add_class_route("expand_flagged_region", &ICf::expandFlaggedRegion);
-  dispatch.add_class_route("adapt_mask", &ICf::adaptMask);
-  dispatch.add_class_route("autopad", &ICf::setAutopad);
+  dispatch.add_class_route("select_sphere", &ICType::selectSphere);
+  dispatch.add_class_route("select_ellipse", &ICType::selectEllipse);
+  dispatch.add_class_route("select_cube", &ICType::selectCube);
+  dispatch.add_class_route("select_nearest", &ICType::selectNearest);
+  dispatch.add_class_route("expand_flagged_region", &ICType::expandFlaggedRegion);
+  dispatch.add_class_route("adapt_mask", &ICType::adaptMask);
+  dispatch.add_class_route("autopad", &ICType::setAutopad);
 
   // Deal with modifications
-  dispatch.add_class_route("modify", &ICf::modify);
-  dispatch.add_class_route("calculate", static_cast<void (ICf::*)(std::string)>(&ICf::calculate));
-  dispatch.add_class_route("filtering_scale", &ICf::setVarianceFilteringScale);
-  dispatch.add_class_route("clear_modifications", static_cast<void (ICf::*)()>(&ICf::clearModifications));
-  dispatch.add_class_route("done", &ICf::done);
-  dispatch.add_class_route("apply_modifications", static_cast<void (ICf::*)()>(&ICf::applyModifications));
-  dispatch.add_class_route("chi2", static_cast<void (ICf::*)()>(&ICf::getFieldChi2));
+  dispatch.add_class_route("modify", &ICType::modify);
+  dispatch.add_class_route("calculate", static_cast<void (ICType::*)(std::string)>(&ICType::calculate));
+  dispatch.add_class_route("filtering_scale", &ICType::setVarianceFilteringScale);
+  dispatch.add_class_route("clear_modifications", static_cast<void (ICType::*)()>(&ICType::clearModifications));
+  dispatch.add_class_route("done", &ICType::done);
+  dispatch.add_class_route("apply_modifications", static_cast<void (ICType::*)()>(&ICType::applyModifications));
+  dispatch.add_class_route("chi2", static_cast<void (ICType::*)()>(&ICType::getFieldChi2));
 
-  dispatch.add_class_route("reverse", static_cast<void (ICf::*)()>(&ICf::reverse));
-  dispatch.add_class_route("reverse_small_k", static_cast<void (ICf::*)(FloatType)>(&ICf::reverseSmallK));
-  dispatch.add_class_route("splice", &ICf::splice);
+  dispatch.add_class_route("reverse", static_cast<void (ICType::*)()>(&ICType::reverse));
+  dispatch.add_class_route("reverse_small_k", static_cast<void (ICType::*)(FloatType)>(&ICType::reverseSmallK));
+  dispatch.add_class_route("splice", &ICType::splice);
 
   // Write objects to files
-  // dispatch.add_class_route("dump_grid", &ICf::dumpGrid);
-  dispatch.add_class_route("dump_grid", static_cast<void (ICf::*)(size_t)>(&ICf::dumpGrid));
-  dispatch.add_class_route("dump_vx", static_cast<void (ICf::*)(size_t)>(&ICf::dumpVelocityX));
-  dispatch.add_class_route("dump_grid_for_field", static_cast<void (ICf::*)(size_t, particle::species)>(&ICf::dumpGrid));
-  dispatch.add_class_route("dump_grid_fourier", static_cast<void (ICf::*)(size_t)>(&ICf::dumpGridFourier));
+  // dispatch.add_class_route("dump_grid", &ICType::dumpGrid);
+  dispatch.add_class_route("dump_grid", static_cast<void (ICType::*)(size_t)>(&ICType::dumpGrid));
+  dispatch.add_class_route("dump_vx", static_cast<void (ICType::*)(size_t)>(&ICType::dumpVelocityX));
+  dispatch.add_class_route("dump_grid_for_field", static_cast<void (ICType::*)(size_t, particle::species)>(&ICType::dumpGrid));
+  dispatch.add_class_route("dump_grid_fourier", static_cast<void (ICType::*)(size_t)>(&ICType::dumpGridFourier));
   dispatch.add_class_route("dump_grid_fourier_for_field",
-                           static_cast<void (ICf::*)(size_t, particle::species)>(&ICf::dumpGridFourier));
-  dispatch.add_class_route("dump_ps", static_cast<void (ICf::*)(size_t)>(&ICf::dumpPS));
-  dispatch.add_class_route("dump_ps_field", static_cast<void (ICf::*)(size_t, particle::species)>(&ICf::dumpPS));
-  dispatch.add_class_route("dump_tipsy", static_cast<void (ICf::*)(std::string)>(&ICf::saveTipsyArray));
-  dispatch.add_class_route("dump_tipsy_field", static_cast<void (ICf::*)(std::string, size_t)>(&ICf::saveTipsyArray));
-  dispatch.add_class_route("dump_mask", &ICf::dumpMask);
+                           static_cast<void (ICType::*)(size_t, particle::species)>(&ICType::dumpGridFourier));
+  dispatch.add_class_route("dump_ps", static_cast<void (ICType::*)(size_t)>(&ICType::dumpPS));
+  dispatch.add_class_route("dump_ps_field", static_cast<void (ICType::*)(size_t, particle::species)>(&ICType::dumpPS));
+  dispatch.add_class_route("dump_tipsy", static_cast<void (ICType::*)(std::string)>(&ICType::saveTipsyArray));
+  dispatch.add_class_route("dump_tipsy_field", static_cast<void (ICType::*)(std::string, size_t)>(&ICType::saveTipsyArray));
+  dispatch.add_class_route("dump_mask", &ICType::dumpMask);
 
   // Load existing random field instead of generating
-  dispatch.add_class_route("import_level", static_cast<void (ICf::*)(size_t, std::string)>(&ICf::importLevel));
+  dispatch.add_class_route("import_level", static_cast<void (ICType::*)(size_t, std::string)>(&ICType::importLevel));
 
   // Extra commands related to the transfer functions:
-  dispatch.add_class_route("baryon_tf_on", &ICf::setUsingBaryons);
-  dispatch.add_class_route("baryons_all_levels", &ICf::setBaryonsOnAllLevels);
+  dispatch.add_class_route("baryon_tf_on", &ICType::setUsingBaryons);
+  dispatch.add_class_route("baryons_all_levels", &ICType::setBaryonsOnAllLevels);
 
   // To debug
-  dispatch.add_deprecated_class_route("zeroLevel", "zero_level", static_cast<void (ICf::*)(
-    size_t)>(&ICf::zeroLevel)); // Retained for backwards compatibility.
-  dispatch.add_class_route("zero_level", static_cast<void (ICf::*)(size_t)>(&ICf::zeroLevel)); // Use this instead.
-  dispatch.add_class_route("zero_level_field", static_cast<void (ICf::*)(size_t, size_t)>(&ICf::zeroLevel));
+  dispatch.add_deprecated_class_route("zeroLevel", "zero_level", static_cast<void (ICType::*)(
+    size_t)>(&ICType::zeroLevel)); // Retained for backwards compatibility.
+  dispatch.add_class_route("zero_level", static_cast<void (ICType::*)(size_t)>(&ICType::zeroLevel)); // Use this instead.
+  dispatch.add_class_route("zero_level_field", static_cast<void (ICType::*)(size_t, size_t)>(&ICType::zeroLevel));
 
   // Set an overall velocity offset for the entire box (useful for testing AMR sensitivity to flows)
-  dispatch.add_class_route("velocity_offset", &ICf::setOffset);
+  dispatch.add_class_route("velocity_offset", &ICType::setOffset);
 
 }
 
@@ -195,25 +194,18 @@ void header(ostream &outf, std::string prefix="") {
 
 }
 
-int main(int argc, char *argv[]) {
-  using namespace std;
 
-  if (argc != 2) {
-    logging::entry() << "usage: genetIC paramfile" << endl;
+template<typename IC>
+int runGenetic(string paramFilename) {
+  ifstream inf;
+  inf.open(paramFilename);
+
+  if (!inf.is_open()) {
+    logging::entry() << "Error: could not open parameter file " << paramFilename << endl;
     return -1;
   }
 
-  ifstream inf;
-  string fname(argv[1]);
-
-  inf.open(fname);
-
-  if (!inf.is_open()) {
-    logging::entry() << "Error: could not open parameter file " << argv[1] << endl;
-    exit(1);
-  }
-
-  tools::ChangeCwdWhileInScope temporary(tools::getDirectoryName(fname));
+  tools::ChangeCwdWhileInScope temporary(tools::getDirectoryName(paramFilename));
 
   ofstream outf;
   outf.open("IC_output.params");
@@ -227,11 +219,11 @@ int main(int argc, char *argv[]) {
   header(cerr);
 
   // Set up the command interpreter to issue commands to main_generator
-  tools::ClassDispatch<ICf, void> dispatch_generator;
+  tools::ClassDispatch<IC, void> dispatch_generator;
   setup_parser(dispatch_generator);
 
   // The main program is contained in this class:
-  ICf generator(dispatch_generator);
+  IC generator(dispatch_generator);
 
 
   auto dispatch = dispatch_generator.specify_instance(generator);
@@ -244,4 +236,58 @@ int main(int argc, char *argv[]) {
   dispatch.run_loop(inf, outf);
 
   return 0;
+}
+
+
+void usageMessage() {
+  using namespace std;
+  cout << "Usage: genetIC paramfile [-f] [-c <cache-size>]" << endl << endl
+       << " The paramfile is a text file of commands (see example provided with genetIC distribution)." << endl << endl
+       << " If option -f is specified, genetIC uses float (32-bit) instead of double (64-bit) internally." << endl
+       << " The output format is unaffected by the internal bit depth." << endl << endl
+       << " If option -c <cache-size> is specified, the transfer function cache is limited to the specified"
+          " number of entries. This can be used to reduce memory usage, but may slow down the code." << endl;
+}
+
+int main(int argc, char *argv[]) {
+  using namespace std;
+
+  bool useFloat = false;
+
+  if (argc<2) {
+    usageMessage();
+    return -1;
+  }
+
+
+  string fname(argv[1]);
+
+  for (int i = 2; i < argc; ++i) {
+    if (strcmp(argv[i], "-f") == 0) {
+      useFloat = true;
+    } else if (strcmp(argv[i], "-c") == 0) {
+      if (i + 1 >= argc) {
+        cerr << "Error: -c option requires an argument" << endl;
+        return -1;
+      }
+      cosmology::lru_cache_size = atoi(argv[++i]);
+    } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+      usageMessage();
+      return 0;
+    } else {
+      if (i != argc - 1) {
+        cerr << "Error: unknown option " << argv[i] << endl;
+        return -1;
+      }
+    }
+  }
+
+
+  if(useFloat) {
+    return runGenetic<ICf>(fname);
+  } else {
+    return runGenetic<ICd>(fname);
+  }
+
+
 }

--- a/genetIC/src/simulation/field/evaluator.hpp
+++ b/genetIC/src/simulation/field/evaluator.hpp
@@ -30,7 +30,7 @@ namespace fields {
     //! \brief Adds this field to the destination field.
     virtual void addTo(Field <DataType, CoordinateType> &destination) const {
 
-      fields::cache::enableInterpolationCaches();
+      fields::cache::enableInterpolationCaches<CoordinateType>();
 
       // A note on the scheduling here: the most costly operations operations are encountered when there is
       // interpolation involved, at which point an thread-local LRU cache tries to reduce some of the workload. The hit
@@ -51,7 +51,7 @@ namespace fields {
       });
 
 
-      fields::cache::disableInterpolationCaches();
+      fields::cache::disableInterpolationCaches<CoordinateType>();
 
 
     }

--- a/genetIC/src/simulation/field/field.hpp
+++ b/genetIC/src/simulation/field/field.hpp
@@ -200,17 +200,18 @@ namespace fields {
 
   public:
     //! Move constructor
-    Field(Field<DataType, CoordinateType> &&move) : pGrid(move.pGrid), data(std::move(move.data)),
+    Field(Field<DataType, CoordinateType> &&move) : pGrid(move.pGrid),
                                                     fourier(move.fourier) {
       fourierManager = std::make_shared<FourierManager>(*this);
+      std::swap(data, move.data);
       assert(data.size() == this->fourierManager->getRequiredDataSize());
-      addMemUsage(data.size() * sizeof(DataType));
     }
 
     //! Move operator
     auto & operator=(Field<DataType, CoordinateType> &&move) {
       assert(move.pGrid == pGrid);
-      data = std::move(move.data);
+      std::swap(data, move.data);
+      assert(data.size() == this->fourierManager->getRequiredDataSize());
       fourier = move.fourier;
       return *this;
     }

--- a/genetIC/src/simulation/field/randomfieldgenerator.hpp
+++ b/genetIC/src/simulation/field/randomfieldgenerator.hpp
@@ -5,6 +5,7 @@
 #include <gsl/gsl_randist.h> //for the gaussian (and other) distributions
 #include <gsl/gsl_errno.h>
 #include <gsl/gsl_spline.h>
+#include <omp.h>
 
 #include "src/simulation/grid/grid.hpp"
 

--- a/genetIC/src/simulation/multilevelgrid/mask.hpp
+++ b/genetIC/src/simulation/multilevelgrid/mask.hpp
@@ -197,8 +197,8 @@ namespace multilevelgrid {
 
       // Field full of zeros
       for (size_t level = 0; level < this->multilevelgrid->getNumLevels(); ++level) {
-        fields.push_back(std::shared_ptr<fields::Field<DataType, T>>(
-          new fields::Field<DataType, T>(this->multilevelgrid->getGridForLevel(level))));
+        fields.push_back(std::make_shared<fields::Field<DataType, T>>(
+          this->multilevelgrid->getGridForLevel(level)));
       }
 
       auto maskfield = std::make_shared<fields::MultiLevelField<DataType>>(*(this->multilevelgrid), fields);

--- a/genetIC/src/tools/lru_cache.hpp
+++ b/genetIC/src/tools/lru_cache.hpp
@@ -1,0 +1,124 @@
+// This is closely based on boost::detail::lru_cache, which is copyright
+// (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//
+// Here, the difference is that the map can have a custom comparator,
+// which is necessary for genetIC's use of weak_ptr as a key.
+
+#ifndef IC_LRU_CACHE_HPP
+#define IC_LRU_CACHE_HPP
+
+#include <map>
+#include <list>
+#include <utility>
+
+#include <boost/optional.hpp>
+
+namespace tools {
+// a cache which evicts the least recently used item when it is full
+  template<class Key, class Value, class KeyComparator=std::less<Key>>
+  class lru_cache {
+  public:
+    typedef Key key_type;
+    typedef Value value_type;
+    typedef std::list<key_type> list_type;
+    typedef std::map<
+      key_type,
+      std::pair<value_type, typename list_type::iterator>,
+      KeyComparator
+    > map_type;
+
+    lru_cache(size_t capacity)
+      : m_capacity(capacity) {
+    }
+
+    ~lru_cache() {
+    }
+
+    size_t size() const {
+      return m_map.size();
+    }
+
+    size_t capacity() const {
+      return m_capacity;
+    }
+
+    bool empty() const {
+      return m_map.empty();
+    }
+
+    bool contains(const key_type &key) {
+      return m_map.find(key) != m_map.end();
+    }
+
+    void insert(const key_type &key, const value_type &value) {
+      typename map_type::iterator i = m_map.find(key);
+      if (i == m_map.end()) {
+        // insert item into the cache, but first check if it is full
+        if (size() >= m_capacity) {
+          // cache is full, evict the least recently used item
+          evict();
+        }
+
+        // insert the new item
+        m_list.push_front(key);
+        m_map[key] = std::make_pair(value, m_list.begin());
+      }
+    }
+
+    boost::optional<value_type> get(const key_type &key) {
+      // lookup value in the cache
+      typename map_type::iterator i = m_map.find(key);
+      if (i == m_map.end()) {
+        // value not in cache
+        return boost::none;
+      }
+
+      // return the value, but first update its place in the most
+      // recently used list
+      typename list_type::iterator j = i->second.second;
+      if (j != m_list.begin()) {
+        // move item to the front of the most recently used list
+        m_list.erase(j);
+        m_list.push_front(key);
+
+        // update iterator in map
+        j = m_list.begin();
+        const value_type &value = i->second.first;
+        m_map[key] = std::make_pair(value, j);
+
+        // return the value
+        return value;
+      } else {
+        // the item is already at the front of the most recently
+        // used list so just return it
+        return i->second.first;
+      }
+    }
+
+    void clear() {
+      m_map.clear();
+      m_list.clear();
+    }
+
+  private:
+    void evict() {
+      // evict item from the end of most recently used list
+      typename list_type::iterator i = --m_list.end();
+      m_map.erase(*i);
+      m_list.erase(i);
+    }
+
+  private:
+    map_type m_map;
+    list_type m_list;
+    size_t m_capacity;
+  };
+}
+
+#endif //IC_LRU_CACHE_HPP

--- a/genetIC/src/tools/numerics/fourier.hpp
+++ b/genetIC/src/tools/numerics/fourier.hpp
@@ -278,14 +278,15 @@ namespace tools {
       /*! \class FieldFourierManager<double>
           \brief Fourier manager class, specialised for real fields
       */
-      template<>
-      class FieldFourierManager<double> : public FieldFourierManagerBase<double> {
+      template<typename T>
+      class FieldFourierManager<T, T> : public FieldFourierManagerBase<T, T> {
       protected:
-        using T=double;
         int size; //!< Number of elements in the set to apply discrete Fourier transform to.
         size_t compressed_size; //!< Compressed size, exploiting symmetry of real discrete Fourier transforms.
-        fftw_plan forwardPlan; //!< Method used for going from real space to Fourier space.
-        fftw_plan reversePlan; //!< Method used for going from Fourier space to real space.
+        fftw_plan forwardPlan; //!< Method used for going from real space to Fourier space, if T is double
+        fftw_plan reversePlan; //!< Method used for going from Fourier space to real space, if T is double
+        fftwf_plan forwardPlanFloat; //!< Method used for going from real space to Fourier space, if T is float
+        fftwf_plan reversePlanFloat; //!< Method used for going from Fourier space to real space, if T is float
 
         //! Re-organises the wave-numbers to lie in the positive quadrant, and returns to a linear index (and whether we conjugated the field)
         auto getRealCoeffLocationAndConjugation(int kx, int ky, int kz) const {
@@ -304,7 +305,7 @@ namespace tools {
           }
           size_t logical_index = kz + compressed_size * ky + compressed_size * size_t(size * kx);
           size_t index_re = 2 * logical_index;
-          assert(index_re + 1 < FieldFourierManagerBase::field.getDataVector().size());
+          assert(index_re + 1 < this->field.getDataVector().size());
 
           return std::make_tuple(conjugate, index_re);
         }
@@ -334,15 +335,15 @@ namespace tools {
             for (int ky = size / 2; ky > -size / 2; --ky) {
               std::tie(unused, loc_source) = getRealCoeffLocationAndConjugation(kx, ky, 0);
               std::tie(unused, loc_dest) = getRealCoeffLocationAndConjugation(-kx, -ky, 0);
-              field[loc_dest] = field[loc_source];
-              field[loc_dest + 1] = -field[loc_source + 1];
+              this->field[loc_dest] = this->field[loc_source];
+              this->field[loc_dest + 1] = -this->field[loc_source + 1];
 
               // on an odd-sized grid, the following is a null op. On an even sized-grid, it sorts out the kz
               // nyquist mode.
               std::tie(unused, loc_source) = getRealCoeffLocationAndConjugation(kx, ky, this->nyquistIfEvenElseZero);
               std::tie(unused, loc_dest) = getRealCoeffLocationAndConjugation(-kx, -ky, this->nyquistIfEvenElseZero);
-              field[loc_dest] = field[loc_source];
-              field[loc_dest + 1] = -field[loc_source + 1];
+              this->field[loc_dest] = this->field[loc_source];
+              this->field[loc_dest + 1] = -this->field[loc_source + 1];
             }
           }
         }
@@ -358,16 +359,16 @@ namespace tools {
         */
         void padForFFTWRealTransform() {
 
-          size_t source_range_end = FieldFourierManagerBase::grid.size3;
-          size_t padding_amount = compressed_size * 2 - FieldFourierManagerBase::grid.size;
+          size_t source_range_end = this->grid.size3;
+          size_t padding_amount = compressed_size * 2 - this->grid.size;
           size_t target_range_end =
-            FieldFourierManagerBase::grid.size * FieldFourierManagerBase::grid.size * 2 * compressed_size -
+            this->grid.size * this->grid.size * 2 * compressed_size -
             padding_amount;
-          auto &data = FieldFourierManagerBase::field.getDataVector();
+          auto &data = this->field.getDataVector();
 
-          while (source_range_end > FieldFourierManagerBase::grid.size) {
-            size_t target_range_start = target_range_end - FieldFourierManagerBase::grid.size;
-            size_t source_range_start = source_range_end - FieldFourierManagerBase::grid.size;
+          while (source_range_end > this->grid.size) {
+            size_t target_range_start = target_range_end - this->grid.size;
+            size_t source_range_start = source_range_end - this->grid.size;
             std::copy_backward(&data[source_range_start], &data[source_range_end], &data[target_range_end]);
             target_range_end = target_range_start - padding_amount;
             source_range_end = source_range_start;
@@ -383,25 +384,27 @@ namespace tools {
           size_t target_range_start = 0;
           size_t source_max = getRequiredDataSize();
 
-          size_t padding_amount = compressed_size * 2 - FieldFourierManagerBase::grid.size;
-          auto &data = FieldFourierManagerBase::field.getDataVector();
+          size_t padding_amount = compressed_size * 2 - this->grid.size;
+          auto &data = this->field.getDataVector();
 
           while (source_range_start < source_max) {
-            size_t source_range_end = source_range_start + FieldFourierManagerBase::grid.size;
+            size_t source_range_end = source_range_start + this->grid.size;
             std::copy(&data[source_range_start], &data[source_range_end], &data[target_range_start]);
             source_range_start = source_range_end + padding_amount;
-            target_range_start += FieldFourierManagerBase::grid.size;
+            target_range_start += this->grid.size;
           }
 
         }
 
       public:
         //! Constructor from a real field
-        FieldFourierManager(fields::Field<double, double> &field) : FieldFourierManagerBase(field) {
-          size = static_cast<int>(FieldFourierManagerBase::grid.size);
-          compressed_size = FieldFourierManagerBase::grid.size / 2 + 1;
+        FieldFourierManager(fields::Field<T, T> &field) : FieldFourierManagerBase<T, T>(field) {
+          size = static_cast<int>(this->grid.size);
+          compressed_size = this->grid.size / 2 + 1;
           forwardPlan = nullptr;
           reversePlan = nullptr;
+          forwardPlanFloat = nullptr;
+          reversePlanFloat = nullptr;
         }
 
         //! Destructor
@@ -413,6 +416,14 @@ namespace tools {
           if (reversePlan != nullptr) {
             fftw_destroy_plan(reversePlan);
             reversePlan = nullptr;
+          }
+          if (forwardPlanFloat != nullptr) {
+            fftwf_destroy_plan(forwardPlanFloat);
+            forwardPlanFloat = nullptr;
+          }
+          if (reversePlanFloat != nullptr) {
+            fftwf_destroy_plan(reversePlanFloat);
+            reversePlanFloat = nullptr;
           }
         }
 
@@ -428,8 +439,8 @@ namespace tools {
 
           if (conj) imag = -imag;
 
-          FieldFourierManagerBase::field[index_re] = re;
-          FieldFourierManagerBase::field[index_re + 1] = imag;
+          this->field[index_re] = re;
+          this->field[index_re + 1] = imag;
 
         }
 
@@ -440,8 +451,8 @@ namespace tools {
 
           std::tie(conj, index_re) = getRealCoeffLocationAndConjugation(kx, ky, kz);
 
-          T re = FieldFourierManagerBase::field[index_re];
-          T im = FieldFourierManagerBase::field[index_re + 1];
+          T re = this->field[index_re];
+          T im = this->field[index_re + 1];
           if (conj)
             im = -im;
           return std::complex<T>(re, im);
@@ -452,44 +463,38 @@ namespace tools {
         size_t getRequiredDataSize() {
           // for FFTW3 real<->complex FFTs
           // see http://www.fftw.org/fftw3_doc/Real_002ddata-DFT-Array-Format.html#Real_002ddata-DFT-Array-Format
-          return 2 * FieldFourierManagerBase::field.getGrid().size2 * (
-            FieldFourierManagerBase::field.getGrid().size / 2 + 1);
+          return 2 * this->field.getGrid().size2 * (
+            this->field.getGrid().size / 2 + 1);
         }
 
         //! Performs the Fourier transform, interfacing with FFTW
         void performTransform() {
-          auto &fieldData = FieldFourierManagerBase::field.getDataVector();
+          auto &fieldData = this->field.getDataVector();
 
           initialise();
 
-          bool transformToFourier = !FieldFourierManagerBase::field.isFourier();
+          bool transformToFourier = !this->field.isFourier();
 
-          fftw_plan plan;
+          fftw_plan plan = nullptr;
+          fftwf_plan planFloat = nullptr; // only one of these two will be used
 
-          int res = static_cast<int>(FieldFourierManagerBase::field.getGrid().size);
-          double norm = pow(static_cast<double>(res), 1.5);
+          int res = static_cast<int>(this->field.getGrid().size);
+          T norm = pow(static_cast<T>(res), 1.5);
 
+          std::tie(plan, planFloat) = getFFTWPlan(transformToFourier);
 
-          if (transformToFourier) {
+          if(transformToFourier) {
             padForFFTWRealTransform();
-            if (forwardPlan == nullptr)
-              forwardPlan = fftw_plan_dft_r2c_3d(res, res, res,
-                                                 &fieldData[0],
-                                                 reinterpret_cast<fftw_complex *>(&fieldData[0]),
-                                                 FFTW_ESTIMATE);
-            plan = forwardPlan;
           } else {
             ensureFourierModesAreMirrored();
-            if (reversePlan == nullptr)
-              reversePlan = fftw_plan_dft_c2r_3d(res, res, res,
-                                                 reinterpret_cast<fftw_complex *>(&fieldData[0]),
-                                                 &fieldData[0],
-                                                 FFTW_ESTIMATE);
-            plan = reversePlan;
           }
 
-
-          fftw_execute(plan);
+          if(plan!=nullptr)
+            fftw_execute(plan);
+          else if(planFloat!=nullptr)
+            fftwf_execute(planFloat);
+          else
+            throw std::runtime_error("No plan available for FFTW transform");
 
 
           if (!transformToFourier) {
@@ -500,20 +505,64 @@ namespace tools {
           fieldData /= norm;
 
 
-          FieldFourierManagerBase::field.setFourier(!FieldFourierManagerBase::field.isFourier());
+          this->field.setFourier(!this->field.isFourier());
 
+        }
+
+      private:
+        auto getFFTWPlan(bool transformToFourier) {
+          auto &fieldData = this->field.getDataVector();
+          int res = static_cast<int>(this->field.getGrid().size);
+          fftw_plan plan(nullptr);
+          fftwf_plan planFloat(nullptr);
+
+          if (transformToFourier) {
+            if (forwardPlan == nullptr && forwardPlanFloat == nullptr) {
+              if(std::is_same<T,double>::value) {
+                forwardPlan = fftw_plan_dft_r2c_3d(res, res, res, reinterpret_cast<double*>(&fieldData[0]),
+                                                   reinterpret_cast<fftw_complex *>(&fieldData[0]),
+                                                   FFTW_ESTIMATE);
+              } else {
+                forwardPlanFloat = fftwf_plan_dft_r2c_3d(res, res, res, reinterpret_cast<float*>(&fieldData[0]),
+                                                         reinterpret_cast<fftwf_complex *>(&fieldData[0]),
+                                                         FFTW_ESTIMATE);
+              }
+            }
+
+            // one, but only one, of these will be nullptr
+            plan = forwardPlan;
+            planFloat = forwardPlanFloat;
+
+          } else {
+            if(reversePlan == nullptr && reversePlanFloat == nullptr) {
+              if(std::is_same<T,double>::value) {
+                reversePlan = fftw_plan_dft_c2r_3d(res, res, res,
+                                                   reinterpret_cast<fftw_complex *>(&fieldData[0]),
+                                                   reinterpret_cast<double*>(&fieldData[0]),
+                                                   FFTW_ESTIMATE);
+              } else {
+                reversePlanFloat = fftwf_plan_dft_c2r_3d(res, res, res,
+                                                         reinterpret_cast<fftwf_complex *>(&fieldData[0]),
+                                                         reinterpret_cast<float*>(&fieldData[0]),
+                                                         FFTW_ESTIMATE);
+              }
+            }
+            // one, but only one, of these will be nullptr
+            plan = reversePlan;
+            planFloat = reversePlanFloat;
+          }
+          return std::make_pair(plan, planFloat);
         }
 
 
       };
 
       //! FieldFourierManager specialisation to deal with Fourier transforms of complex fields.
-      template<>
-      class FieldFourierManager<std::complex<double>> : public FieldFourierManagerBase<std::complex<double>> {
-        using T=double;
+      template<typename T>
+      class FieldFourierManager<std::complex<T>, T> : public FieldFourierManagerBase<std::complex<T>, T> {
       public:
         //! Constructor from a complex field
-        FieldFourierManager(fields::Field<std::complex<T>, T> &field) : FieldFourierManagerBase(field) {
+        FieldFourierManager(fields::Field<std::complex<T>, T> &field) : FieldFourierManagerBase<std::complex<T>, T>(field) {
 
         }
 
@@ -521,36 +570,36 @@ namespace tools {
         void setFourierCoefficient(int kx, int ky, int kz, const std::complex<T> &val) {
           size_t id_k, id_negk;
 
-          id_k = grid.getIndexFromCoordinate(Coordinate<int>(kx, ky, kz));
-          id_negk = grid.getIndexFromCoordinate(Coordinate<int>(-kx, -ky, -kz));
+          id_k = this->grid.getIndexFromCoordinate(Coordinate<int>(kx, ky, kz));
+          id_negk = this->grid.getIndexFromCoordinate(Coordinate<int>(-kx, -ky, -kz));
 
-          field[id_k] = val;
-          field[id_negk] = std::conj(val);
+          this->field[id_k] = val;
+          this->field[id_negk] = std::conj(val);
         }
 
         //! Returns the specified Fourier coefficient
         std::complex<T> getFourierCoefficient(int kx, int ky, int kz) const {
-          return field[grid.getIndexFromCoordinate(Coordinate<int>(kx, ky, kz))];
+          return this->field[this->grid.getIndexFromCoordinate(Coordinate<int>(kx, ky, kz))];
         }
 
         //! Returns space required to store Fourier information (always the size of the full grid for Fourier transforms of complex fields)
         size_t getRequiredDataSize() {
-          return field.getGrid().size3;
+          return this->field.getGrid().size3;
         }
 
         //! Performs the Fourier transform operation, in this cases assuming the field is generic (ie, complex)
         void performTransform() {
 
-          auto &fieldData = field.getDataVector();
+          auto &fieldData = this->field.getDataVector();
 
           initialise();
 
           fftw_plan plan;
 
-          int res = static_cast<int>(field.getGrid().size);
+          int res = static_cast<int>(this->field.getGrid().size);
           double norm = pow(static_cast<double>(res), 1.5);
 
-          if (!field.isFourier())
+          if (!this->field.isFourier())
             plan = fftw_plan_dft_3d(res, res, res,
                                     reinterpret_cast<fftw_complex *>(&fieldData[0]),
                                     reinterpret_cast<fftw_complex *>(&fieldData[0]),
@@ -569,27 +618,28 @@ namespace tools {
           using tools::numerics::operator/=;
           fieldData /= norm;
 
-          field.setFourier(!field.isFourier());
+          this->field.setFourier(!this->field.isFourier());
         }
 
 
       };
 
       //! A dummy specialisation expressing that fourier transforms over boolean masks can't be done!
-      template<>
-      class FieldFourierManager<char> : public FieldFourierManagerBase<char, double> {
+      template<typename T>
+      class FieldFourierManager<char, T> : public FieldFourierManagerBase<char, T> {
+        using ComplexType = std::complex<char>;
       public:
 
         void ensureFourierModesAreMirrored() override {
 
         }
 
-        FieldFourierManager(fields::Field<char, double> &field) : FieldFourierManagerBase(field) {
+        FieldFourierManager(fields::Field<char, T> &field) : FieldFourierManagerBase<char, T>(field) {
 
         }
 
         size_t getRequiredDataSize() {
-          return field.getGrid().size3;
+          return this->field.getGrid().size3;
         }
 
         void performTransform() {
@@ -635,54 +685,6 @@ namespace tools {
 
         return out; // TODO - this seems quite inefficient, because it returns the field by value (after already creating a copy of it once already!)
       };
-
-      //! Performs FFT for specified field (only implemented for T = std::complex<double>, S = double)
-      template<typename T, typename S>
-      void performFFT(fields::Field<T, S> &field);
-
-
-      //! Specialisation to perform FFT for T = std::complex<double>, S = double
-      template<>
-      void performFFT(fields::Field<std::complex<double>, double> &field) {
-
-        auto &fieldData = field.getDataVector();
-
-        initialise();
-
-        fftw_plan plan;
-        size_t i;
-
-        int res = static_cast<int>(field.getGrid().size);
-
-        double norm = pow(static_cast<double>(res), 1.5);
-        size_t len = static_cast<size_t>(res * res);
-        len *= res;
-
-        if (!field.isFourier())
-          plan = fftw_plan_dft_3d(res, res, res,
-                                  reinterpret_cast<fftw_complex *>(&fieldData[0]),
-                                  reinterpret_cast<fftw_complex *>(&fieldData[0]),
-                                  FFTW_FORWARD, FFTW_ESTIMATE);
-
-        else
-          plan = fftw_plan_dft_3d(res, res, res,
-                                  reinterpret_cast<fftw_complex *>(&fieldData[0]),
-                                  reinterpret_cast<fftw_complex *>(&fieldData[0]),
-                                  FFTW_BACKWARD, FFTW_ESTIMATE);
-
-
-        fftw_execute(plan);
-        fftw_destroy_plan(plan);
-
-#pragma omp parallel for schedule(static) private(i)
-        for (i = 0; i < len; i++)
-          fieldData[i] /= norm;
-
-        field.setFourier(!field.isFourier());
-
-
-      }
-
 
     }
   }


### PR DESCRIPTION
* Fix use of genetIC with float
* Allow floats to be used by passing a command-line flag (-f), rather than recompiling
* Add a memory watchdog which regularly reports memory usage
* Add command-line option (-c <n>) to change size of transfer function cache (reduce to zero to minimise memory usage)