### PR TITLE
Add possibility to use cuFFT to perform FFTs

### DIFF
--- a/genetIC/Makefile
+++ b/genetIC/Makefile
@@ -49,7 +49,7 @@ GIT_VARIABLES = -DGIT_VERSION='"$(GIT_VERSION)"' -DGIT_MODIFIED='"$(GIT_MODIFIED
 HOST	= $(shell if [ `which scutil 2>/dev/null` ]; then scutil --get ComputerName | cut -c1-5; else hostname | cut -c1-5 ; fi )
 HOST3	= $(shell hostname | cut -c1-3)
 
-USE_CUFFT=1
+USE_CUFFT=0
 ifeq ($(USE_CUFFT), 1)
 	CPATH = /opt/local/include/:/opt/cuda/include/cufft/:/opt/cuda/targets/x86_64-linux/include/
 	LPATH = /opt/local/lib:/opt/cuda/lib64/

--- a/genetIC/Makefile
+++ b/genetIC/Makefile
@@ -38,7 +38,6 @@ GSLFLAGS = -lgsl -lgslcblas
 FFTW = -DFFTW3 -DFFTW_THREADS
 FFTWLIB = -lfftw3 -lfftw3_threads
 
-
 # Provide information on the git repository, to be printed out on each run
 GIT_MODIFIED = $(shell git ls-files -m 2>/dev/null | tr "\n" " " )
 GIT_VERSION = $(shell git rev-parse --short HEAD 2>/dev/null)
@@ -50,6 +49,18 @@ GIT_VARIABLES = -DGIT_VERSION='"$(GIT_VERSION)"' -DGIT_MODIFIED='"$(GIT_MODIFIED
 HOST	= $(shell if [ `which scutil 2>/dev/null` ]; then scutil --get ComputerName | cut -c1-5; else hostname | cut -c1-5 ; fi )
 HOST3	= $(shell hostname | cut -c1-3)
 
+USE_CUFFT=1
+ifeq ($(USE_CUFFT), 1)
+	CPATH = /opt/local/include/:/opt/cuda/include/cufft/:/opt/cuda/targets/x86_64-linux/include/
+	LPATH = /opt/local/lib:/opt/cuda/lib64/
+
+	CODEOPTIONS += -DUSE_CUFFT
+	FFTW = -DFFTW3
+	FFTWLIB = -lcufft -lcufftw
+	OLD_CFLAGS=$(CFLAGS)
+	CFLAGS=-O3 -I`pwd` -Xcompiler="-O3 -fopenmp -std=c++14 -Wall"
+	CXX=nvcc
+endif
 ifeq ($(HOST3), pfe)
 	CXX = /nasa/pkgsrc/2016Q2/gcc5/bin/g++
 	CPATH = /u/apontzen/genetIC/genetIC:/nasa/gsl/1.14/include/:/nasa/intel/Compiler/2016.2.181/compilers_and_libraries_2016.2.181/linux/mkl/include/fftw

--- a/genetIC/src/tools/numerics/fourier.hpp
+++ b/genetIC/src/tools/numerics/fourier.hpp
@@ -3,7 +3,11 @@
 
 
 #include <stdexcept>
+#ifdef USE_CUFFT
+#include <cufftw.h>
+#else
 #include <fftw3.h>
+#endif
 
 #ifdef _OPENMP
 
@@ -34,6 +38,10 @@ namespace tools {
         if (fftwThreadsInitialised)
           return;
 
+#ifdef USE_CUFFT
+       // nothing to do
+       logging::entry() << "Using CUFFT" << std::endl;
+#else
 #ifdef FFTW_THREADS
         if (fftw_init_threads() == 0)
           throw std::runtime_error("Cannot initialize FFTW threads");
@@ -68,6 +76,7 @@ namespace tools {
 #endif
 #else
         logging::entry() << "Note: FFTW Threads are not enabled" << std::endl;
+#endif
 #endif
         fftwThreadsInitialised = true;
       }


### PR DESCRIPTION
This adds the minimal changes to compile using cuFFT instead of FFTW3 as a backend for performing the Fourier transforms.

This may help when the FFT is dominating the cost, but is otherwise not offering any speedup (nor does it slow down the code).