### PR TITLE
Splice potential

### DIFF
--- a/genetIC/Makefile
+++ b/genetIC/Makefile
@@ -63,10 +63,10 @@ ifeq ($(USE_CUFFT), 1)
 endif
 
 ifeq ($(HOST3), Ana)
-       CXX = /opt/homebrew/bin/c++-13
-       CPATH ?= /opt/local/include/
-       LPATH ?= /opt/local/lib
-       CFLAGS = -O3 -fopenmp -std=c++14 -fdiagnostics-color=auto -I`pwd` -DOPENMP -DDOUBLEPRECISION
+	CXX = /opt/homebrew/bin/c++-13
+	CPATH = /opt/homebrew/include/
+	LPATH = /opt/homebrew/lib
+	CFLAGS = -O3 -fopenmp -std=c++14 -fdiagnostics-color=auto -I`pwd` -DOPENMP -DDOUBLEPRECISION
 endif
 
 ifeq ($(HOST3), pfe)

--- a/genetIC/Makefile
+++ b/genetIC/Makefile
@@ -8,7 +8,7 @@ CFLAGS ?= -Wall -g -lpthread -O3 -fopenmp -std=c++14 -fdiagnostics-color=auto -I
 # -DVELOCITY_MODIFICATION_GRADIENT_FOURIER_SPACE: As the name suggests, use "ik" as the gradient operator; otherwise
 #    uses a fourth order stencil in real space. Enabling this is essential if you disable CUBIC_INTERPOLATION.
 # -DZELDOVICH_GRADIENT_FOURIER_SPACE: Same as VELOCITY_MODIFICATION_GRADIENT_FOURIER_SPACE, but for computing the
-#    Zeldovich displacement field.
+#    Zeldovich displacement field. Should be commented out if splicing the potential.
 # -DFRACTIONAL_K_SPLIT: This defines the characteristic k0 of the filter used to split information between zoom levels,
 #    defined by k0 = k_nyquist * FRACTIONAL_K_SPLIT, where k_nyquist is the Nyquist frequency of the lower-resolution grid.
 #    Higher values correlate the zoom grids more precisely with the unzoomed base grids, but at the cost of errors
@@ -61,6 +61,14 @@ ifeq ($(USE_CUFFT), 1)
 	CFLAGS=-O3 -I`pwd` -Xcompiler="-O3 -fopenmp -std=c++14 -Wall"
 	CXX=nvcc
 endif
+
+ifeq ($(HOST3), Ana)
+       CXX = /opt/homebrew/bin/c++-13
+       CPATH ?= /opt/local/include/
+       LPATH ?= /opt/local/lib
+       CFLAGS = -O3 -fopenmp -std=c++14 -fdiagnostics-color=auto -I`pwd` -DOPENMP -DDOUBLEPRECISION
+endif
+
 ifeq ($(HOST3), pfe)
 	CXX = /nasa/pkgsrc/2016Q2/gcc5/bin/g++
 	CPATH = /u/apontzen/genetIC/genetIC:/nasa/gsl/1.14/include/:/nasa/intel/Compiler/2016.2.181/compilers_and_libraries_2016.2.181/linux/mkl/include/fftw

--- a/genetIC/src/main.cpp
+++ b/genetIC/src/main.cpp
@@ -135,7 +135,16 @@ void setup_parser(tools::ClassDispatch<ICType, void> &dispatch) {
 
   dispatch.add_class_route("reverse", static_cast<void (ICType::*)()>(&ICType::reverse));
   dispatch.add_class_route("reverse_small_k", static_cast<void (ICType::*)(FloatType)>(&ICType::reverseSmallK));
-  dispatch.add_class_route("splice", &ICType::splice);
+  dispatch.add_deprecated_class_route("splice_accuracy", "set_splice_accuracy", &ICType::set_splice_accuracy);
+  dispatch.add_class_route("set_splice_accuracy", &ICType::set_splice_accuracy);
+  dispatch.add_class_route("splice_seedfourier_parallel", &ICType::splice_seedfourier_parallel);
+  dispatch.add_class_route("restart_splice", &ICType::restart_splice);
+  dispatch.add_class_route("set_minimization", &ICType::set_minimization);
+  dispatch.add_deprecated_class_route("splice", "splice_density", &ICType::splice_density);
+  dispatch.add_class_route("splice_density", &ICType::splice_density);
+  dispatch.add_class_route("splice_potential", &ICType::splice_potential);
+
+  dispatch.add_class_route("stop_after", &ICType::stop_after);
 
   // Write objects to files
   // dispatch.add_class_route("dump_grid", &ICType::dumpGrid);

--- a/genetIC/src/simulation/field/field.hpp
+++ b/genetIC/src/simulation/field/field.hpp
@@ -361,6 +361,19 @@ namespace fields {
       }
     }
 
+    //! Single grid maximum. Only implemented for real space
+    auto Maximum() const {
+      assert(!isFourier());
+
+      tools::datatypes::strip_complex<DataType> max=0;
+      size_t N = data.size();
+      
+      for(size_t i=0; i<N; i++) {
+        max = std::max(max, std::abs(data[i]));
+      }
+      return max;
+    }
+
     //! Single grid inner product. Only implemented for real space.
     auto innerProduct(const Field<DataType, CoordinateType> & other) const {
       assert(!other.isFourier());

--- a/genetIC/src/simulation/modifications/splice.hpp
+++ b/genetIC/src/simulation/modifications/splice.hpp
@@ -4,6 +4,7 @@
 #include <complex>
 #include <src/tools/data_types/complex.hpp>
 #include <src/tools/numerics/cg.hpp>
+#include <src/tools/numerics/minres.hpp>
 
 namespace modifications {
   template<typename T>

--- a/genetIC/src/tools/numerics/minres.hpp
+++ b/genetIC/src/tools/numerics/minres.hpp
@@ -199,4 +199,4 @@ namespace tools {
   }
 }
 
-+#endif
+#endif

--- a/genetIC/src/tools/numerics/minres.hpp
+++ b/genetIC/src/tools/numerics/minres.hpp
@@ -1,0 +1,202 @@
+#ifndef IC_MINRES_HPP
+#define IC_MINRES_HPP
+
+#include <functional>
+#include <src/simulation/field/field.hpp>
+#include <src/tools/data_types/complex.hpp>
+#include <src/tools/logging.hpp>
+#include <ctime>
+#include <iostream>
+#include <fstream>
+#include <sys/stat.h>
+
+namespace tools {
+  namespace numerics {
+
+    /* Adapted from https://stanford.edu/group/SOL/reports/SOL-2011-2R.pdf */
+    template<typename T>
+    fields::Field<T> minres(std::function<fields::Field<T>(fields::Field<T> &)> A,
+                            fields::Field<T> &b,
+                            double rtol = 1e-6,
+                            double atol = 1e-12,
+                            bool restart = false,
+                            bool stop = false,
+                            double brakeTime = 0)
+    {
+      fields::Field<T> x(b);
+      x *= 0;
+      fields::Field<T> r(b);
+      fields::Field<T> s(b);
+      s = A(r);
+
+      fields::Field<T> p(r);
+      fields::Field<T> q(s);
+
+      // auto toltest = 1e-8;     // Default tolerance (meant to even include 1024^3 potential splicing)
+
+      double scaleNorm = sqrt(b.innerProduct(b));
+      double scaleMax = b.Maximum();
+      double rho = r.innerProduct(s);
+
+      size_t dimension = b.getGrid().size3;
+
+      /*
+      if (rtol != 2e-4) {
+
+        // Lowering tolerance for lower resolution fields
+        if (dimension == 512*512*512)
+          toltest = 1e-7;
+        if (dimension == 256*256*256) {
+          toltest = 1e-6;
+          brakeTime = 24; // Perhaps a time dependence instead of trying to achieve the
+                          // exact tolerance is better
+        }
+      }
+      */
+
+      size_t max_iterations = dimension * 10;
+      double old_norm = 0;
+
+      size_t iter = 0;
+      //setting variables from last restart
+      /*
+      if (restart == true) {
+          logging::entry() << "Loading restart variables" << std::endl;
+
+          std::string variables = ".variables";
+          std::string directory = output_path + variables;
+
+          x.loadGridData(directory + "/x");
+          r.loadGridData(directory + "/r");
+          q.loadGridData(directory + "/q");
+          p.loadGridData(directory + "/p");
+        
+          std::ifstream file;
+
+          file.open (directory + "/rho.txt");
+          file >> rho;
+          file.close();
+
+          file.open (directory + "/iter.txt");
+          file >> iter;
+          file.close();
+
+      }
+      */
+
+      if (stop == true){
+
+        const std::time_t brakeDuration = brakeTime * 3600; // Calculate the duration in seconds for the brake time
+        const std::time_t startTime = std::time(nullptr);   // Get the current time at splicing start
+
+        logging::entry() << "Splicing will stop after " << brakeTime << " hours, or when the maximum drops below " << rtol * scaleMax << std::endl;
+
+        // Start iteration
+        for(; iter<max_iterations; ++iter) {
+
+          // We have q = A(p), but no need to compute it again
+          double alpha = rho / q.innerProduct(q);
+          x.addScaled(p, alpha);
+          r.addScaled(q, -alpha);
+
+          double norm = sqrt(r.innerProduct(r));
+          double max = r.Maximum();
+
+          if (max < rtol * scaleMax || norm < atol)
+            break;
+
+          const std::time_t currentTime = std::time(nullptr); // Get the current time
+          const std::time_t elapsedTime = currentTime - startTime; // Calculate the elapsed time
+          
+          logging::entry() << "MINRES iteration " << iter << " maximum=" << max << std::endl;
+
+          s = A(r);
+          double rhobar = rho;
+          rho = r.innerProduct(s);
+          double beta = rho / rhobar;
+          p *= beta;
+          p += r;
+
+          q *= beta;
+          q += s;
+
+          if (elapsedTime >= brakeDuration) {
+
+            logging::entry() << "Maximum time reached" << std::endl;
+            break;
+          }
+            //if (max < rtol * scaleMax || norm < atol) {
+
+            //  logging::entry() << "Maximum time reached" << std::endl;
+            
+              // Save current minimization variables if time limit reached
+              /*            
+              std::string variables = ".variables";
+              std::string directory = output_path + variables;
+
+              mkdir(directory.c_str(), 0777);
+
+              //save fields
+              x.dumpGridData(directory + "/x");
+              r.dumpGridData(directory + "/r");
+              q.dumpGridData(directory + "/q");
+              p.dumpGridData(directory + "/p");
+
+              //save variables
+              std::ofstream file;
+
+              file.open (directory + "/rho.txt");
+              file << rho;
+              file.close();
+
+              file.open (directory + "/iter.txt");
+              file << iter + 1;
+              file.close();
+              */
+
+            //  break;
+
+            //}
+        }
+
+          // Save old norm
+          // old_norm = norm;
+      }
+      else {
+
+        logging::entry() << "Splicing will stop when the maximum drops below " << rtol * scaleMax << std::endl;
+        for(; iter<max_iterations; ++iter) {
+
+          // We have q = A(p), but no need to compute it again
+          double alpha = rho / q.innerProduct(q);
+          x.addScaled(p, alpha);
+          r.addScaled(q, -alpha);
+
+          double norm = sqrt(r.innerProduct(r));
+          double max = r.Maximum();
+
+          if (max < rtol * scaleMax || norm < atol)
+            break;
+          
+          logging::entry() << "MINRES iteration " << iter << " maximum=" << max << std::endl;
+
+          s = A(r);
+          double rhobar = rho;
+          rho = r.innerProduct(s);
+          double beta = rho / rhobar;
+          p *= beta;
+          p += r;
+
+          q *= beta;
+          q += s;
+        }
+      }
+
+      logging::entry() << "MINRES ended after " << iter << " iterations" << std::endl;
+
+      return x;
+    }
+  }
+}
+
++#endif


### PR DESCRIPTION
Adding a few functionalities, the biggest being the ability to splice the potential field instead of only the density field. Added an additional minimization technique (MINRES) which appears to be much faster than CG for both splicing types. To perform potential splicing, one should comment out the -DZELDOVICH_GRADIENT_FOURIER_SPACE flag in the Makefile, and enable MINRES (in the param file using set_minimization MINRES).